### PR TITLE
Fixed drawing misalignment of PersonWalkingArrowRight icon

### DIFF
--- a/TextAdvance/Gui/EntityOverlay.cs
+++ b/TextAdvance/Gui/EntityOverlay.cs
@@ -83,7 +83,7 @@ public unsafe sealed class EntityOverlay : IDisposable
         {
             var size = ImGuiHelpers.GetButtonSize(FontAwesomeIcon.PersonWalkingArrowRight.ToIconString());
             ImGuiHelpers.ForceNextWindowMainViewport();
-            ImGuiHelpers.SetNextWindowPosRelativeMainViewport((pos - size));
+            ImGuiHelpers.SetNextWindowPosRelativeMainViewport((pos - size - ImGuiHelpers.MainViewport.Pos));
             ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
             if (ImGui.Begin($"##TextAdvanceButton-{obj.Address}", ImGuiEx.OverlayFlags & ~ImGuiWindowFlags.NoMouseInputs | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.AlwaysUseWindowPadding))
             {


### PR DESCRIPTION
Fixed a drawing misalignment of the PersonWalkingArrowRight icon when Dalamud's `Enable multi-monitor windows` option is enabled.